### PR TITLE
CHORE-update-gitignore-for-macOS-and-Unity-6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,9 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 [Aa]ssets[Ss]treamingAssets/aa.meta
 [Aa]ssets[Ss]treamingAssets/aa/*
+
+# macOS folder attributes
+.DS_Store
+
+# Unity 6.2 AI generated assets data
+[Gg]enerated[Aa]ssets/


### PR DESCRIPTION
### Chores:

- Update the `.gitignore` file to ignore macOS folder attributes and AI generated asset data from __Unity 6.2__.